### PR TITLE
Fix PWA manifest link

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -19,7 +19,6 @@ const Home: React.FC = () => (
       <link rel="apple-touch-icon" sizes="180x180" href="/icons/apple-touch-icon.png" />
       <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32x32.png" />
       <link rel="icon" type="image/png" sizes="16x16" href="/icons/favicon-16x16.png" />
-      <link rel="manifest" href="/icons/site.webmanifest" />
       <link rel="mask-icon" href="/icons/safari-pinned-tab.svg" color="#5bbad5" />
       <link rel="shortcut icon" href="/icons/favicon.ico" />
       <meta name="msapplication-TileColor" content="#da532c" />


### PR DESCRIPTION
Turned out I had included two <link> tags by mistake. Merging this directly